### PR TITLE
Remove UK Data protection act

### DIFF
--- a/PERSONAL_DATA_DISCLOSURE.md
+++ b/PERSONAL_DATA_DISCLOSURE.md
@@ -51,7 +51,6 @@ The following laws and policies were considered when creating the list of person
   * https://www.newamerica.org/cybersecurity-initiative/digichina/blog/translation-cybersecurity-law-peoples-republic-china/
   * http://en.east-concord.com/zygd/Article/20203/ArticleContent_1690.html?utm_source=Mondaq&utm_medium=syndication&utm_campaign=LinkedIn-integration
 * [Personal Data Protection Bill, 2019 (India)](https://www.prsindia.org/billtrack/personal-data-protection-bill-2019)
-* [Data protection act 2018 (UK)](https://www.legislation.gov.uk/ukpga/2018/12/section/3/enacted)
 
 ---
 


### PR DESCRIPTION
“Personal data” in the UK Data protection act has the same
meaning as it has in the GDPR.

Quote from
https://www.legislation.gov.uk/ukpga/2018/12/section/5/enacted

"Terms used in Chapter 2 of this Part and in the GDPR have
the same meaning in Chapter 2 as they have in the GDPR."

"Terms used in Chapter 3 of this Part and in the applied GDPR have
the same meaning in Chapter 3 as they have in the applied GDPR."

Note that GDPR is a EU regulation. EU regulations are binding
in its entirety and directly applicable in all Member States:
https://en.wikipedia.org/wiki/Regulation_(European_Union)

Therefore it is a waste of time to ask all module maintainers
to check both GDPR and UK Data protection act whether data
processed by a module falls under the definition of "Personal data".

Please remove the reference to UK Data protection act.