### PR TITLE
GDPR links

### DIFF
--- a/PERSONAL_DATA_DISCLOSURE.md
+++ b/PERSONAL_DATA_DISCLOSURE.md
@@ -44,7 +44,10 @@ For the purposes of this form, "store" includes the following:
 
 ## Privacy Laws, Regulations, and Policies
 The following laws and policies were considered when creating the list of personal data fields above.
-* [General Data Protection Regulation (GDPR)](https://gdpr.eu/)
+* [General Data Protection Regulation (GDPR)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02016R0679-20160504)
+  * [What are identifiers and related factors? (ico.org.uk)](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/what-is-personal-data/what-are-identifiers-and-related-factors/)
+  * [What is the meaning of 'relates to'? (ico.org.uk)](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/what-is-personal-data/what-is-the-meaning-of-relates-to/)
+  * [Opinion 4/2007 on the concept of personal data (Article 29 working party)](https://ec.europa.eu/justice/article-29/documentation/opinion-recommendation/files/2007/wp136_en.pdf)
 * [California Consumer Privacy Act (CCPA)](https://oag.ca.gov/privacy/ccpa)
 * [U.S. Department of Labor: Guidance on the Protection of Personal Identifiable Information](https://www.dol.gov/general/ppii)
 * Cybersecurity Law of the People's Republic of China

--- a/PERSONAL_DATA_DISCLOSURE.md
+++ b/PERSONAL_DATA_DISCLOSURE.md
@@ -43,7 +43,7 @@ For the purposes of this form, "store" includes the following:
 **NOTE** This is not intended to be a comprehensive list, but instead provide a starting point for module developers/maintainers to use.
 
 ## Privacy Laws, Regulations, and Policies
-The following laws and policies were considered when creating the list of personal data fields above.
+Numerous laws and policies were considered when creating the list of personal data fields above.  For additional information, please refer to the following:
 * [General Data Protection Regulation (GDPR)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02016R0679-20160504)
   * [What are identifiers and related factors? (ico.org.uk)](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/what-is-personal-data/what-are-identifiers-and-related-factors/)
   * [What is the meaning of 'relates to'? (ico.org.uk)](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/what-is-personal-data/what-is-the-meaning-of-relates-to/)


### PR DESCRIPTION
* Remove the link to https://gdpr.eu/ that isn't an official website.
  "GDPR.EU is a website operated by Proton Technologies AG".
  "This is not an official EU Commission or Government resource."
  https://gdpr.eu/terms-and-conditions/#footer
* Add a link to the consolidated GDPR text at eur-lex.europa.eu.
* Add links to the ico.org.uk explanations about "identifiers and related factors"
  and "the meaning of 'relates to'". They were written before brexit and
  UK GDPR personal data definition continues to refer to EU GDPR.
* Link to Article 29 working party opinion because the EU personal data definition
  wording hasn't changed since then.