### PR TITLE
Add dates and improve note

### DIFF
--- a/PERSONAL_DATA_DISCLOSURE.md
+++ b/PERSONAL_DATA_DISCLOSURE.md
@@ -1,3 +1,6 @@
+_Last Updated: (date form was last changed)_
+_Last Reviewed: (date form was last reviewed for accuracy)_
+
 ## Overview
 
 The purpose of this form is to disclose the types of personal data[^1] (PD) stored by each module.  This information enables those hosting FOLIO to better manage and comply with various privacy laws and restrictions, e.g. GDPR.
@@ -58,7 +61,7 @@ Information can be combined with others to form a person’s identity.
 - [ ] Photographs of users (profile picture)
 <!--- - [ ] Other PD - Please list as needed -->
 
-**NOTE** This is not intended to be a comprehensive list, but instead provide a starting point for module developers/maintainers to use.
+**NOTE** This is not intended to be a comprehensive list, but instead provides a starting point for module developers/maintainers to use. If needed, append additional lines and check those accordingly.
 
 ## Privacy Laws, Regulations, and Policies
 


### PR DESCRIPTION
The Privacy SIG suggested two more additions

1. Last Updated and Last Reviewed dates. We want to encourage regular review of the form by module developers and POs. However, the data in the form may not change for years at a time, especially for very stable modules. We want to be able to demonstrate that even if the form hasn't been updated in 5 years, it may still be accurate.
2. Expanded note to make it clear that it is okay to add personal data items to the form as needed.